### PR TITLE
ciao-launcher: Fix improper naming

### DIFF
--- a/ciao-launcher/deps.go
+++ b/ciao-launcher/deps.go
@@ -28,7 +28,7 @@ var launcherClearLinuxCommonDeps = []osprepare.PackageRequirement{
 	{BinaryName: "/usr/bin/qemu-system-x86_64", PackageName: "cloud-control"},
 	{BinaryName: "/usr/bin/xorriso", PackageName: "cloud-control"},
 	{BinaryName: "/usr/sbin/fuser", PackageName: "cloud-control"},
-	{Binaryname: "/usr/bin/openvswitch", PackageName: "cloud-control"},
+	{BinaryName: "/usr/bin/openvswitch", PackageName: "cloud-control"},
 
 }
 

--- a/ciao-launcher/network.go
+++ b/ciao-launcher/network.go
@@ -61,7 +61,7 @@ func initNetworkPhase1() error {
 		ManagementNet: mnetList,
 		ComputeNet:    cnetList,
 		//Mode:          libsnnet.GreTunnel,
-		Mode:          OvsGreTunnel,
+		Mode:          libsnnet.OvsGreTunnel,
 	}
 
 	libsnnet.CnMaxAPIConcurrency = 1


### PR DESCRIPTION
Reference libsnnet network mode variable via the package name and fix
improperly named variable in deps.go.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>