### PR TITLE
Rename OVS bridge destroy function

### DIFF
--- a/networking/libsnnet/cn_test.go
+++ b/networking/libsnnet/cn_test.go
@@ -818,7 +818,7 @@ func TestCN_OVSWhitebox(t *testing.T) {
 	bridgeAlias := fmt.Sprintf("br_%s_%s_%s", tenantUUID, subnetUUID, concUUID)
 
 	if assert.NotNil(createOvsBridge(bridgeAlias)) {
-		defer func() { _ = destroyBridgeCli(bridgeAlias) }()
+		defer func() { _ = destroyOvsBridge(bridgeAlias) }()
 
 		// Create the tunnel to connect to the CNCI
 		// local := cnIP

--- a/networking/libsnnet/ovs_bridge.go
+++ b/networking/libsnnet/ovs_bridge.go
@@ -18,7 +18,7 @@ func createOvsBridge(bridgeId string) error {
 	return nil
 }
 
-func destroyBridgeCli(bridgeId string) error {
+func destroyOvsBridge(bridgeId string) error {
 	// Example: ovs-vsctl del-br ovs-br1
 	args := []string{"del-br", bridgeId}
 


### PR DESCRIPTION
Rename to something more general to allow for future change in
implementation without making it necessary to change function name.