### PR TITLE
OVS Networking: Configure port with IP address

### DIFF
--- a/networking/libsnnet/cn.go
+++ b/networking/libsnnet/cn.go
@@ -992,6 +992,9 @@ func createAndEnableBridge(bridge *Bridge, gre *GreTunEP, mode NetworkMode) erro
 		if err := addPortInternal(bridge.GlobalID, gre.GlobalID); err != nil {
 			return fmt.Errorf("Internal port creation failed %s %s", gre.GlobalID, err.Error())
 		}
+		if err := ifconfigInterface(gre.GlobalID, gre.LocalIP.String()); err != nil {
+			return fmt.Errorf("Interface Configuration failed %s %s %s", gre.GlobalID, gre.LocalIP.String(), err.Error())
+		}
 		if err := createGrePort(bridge.GlobalID, gre.GlobalID, gre.RemoteIP.String()); err != nil {
 			return fmt.Errorf("GRE creation failed %s %s %s", gre.GlobalID, bridge.GlobalID, err.Error())
 		}

--- a/networking/libsnnet/cnci.go
+++ b/networking/libsnnet/cnci.go
@@ -397,6 +397,9 @@ func createCnciTunnel(bridge *Bridge, gre *GreTunEP, mode NetworkMode) (err erro
 		if err = addPortInternal(bridge.GlobalID, gre.GlobalID); err != nil {
 			return err
 		}
+		if err := ifconfigInterface(gre.GlobalID, gre.LocalIP.String()); err != nil {
+			return err
+		}
 		if err = createGrePort(bridge.GlobalID, gre.GlobalID, gre.RemoteIP.String()); err != nil {
 			return err
 		}

--- a/networking/libsnnet/ovs_gre.go
+++ b/networking/libsnnet/ovs_gre.go
@@ -2,6 +2,7 @@ package libsnnet
 
 import (
 	"fmt"
+	"os/exec"
 )
 
 func addPortInternal(bridgeId string, portId string) error {
@@ -13,6 +14,14 @@ func addPortInternal(bridgeId string, portId string) error {
 		return err
 	}
 
+	return nil
+}
+
+func ifconfigInterface(portID string, localIP string) error {
+	args := []string{portID, localIP}
+	if _, err := exec.Command("ifconfig", args...).Output(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -35,4 +44,3 @@ func delGrePort(bridgeId string, portId string) error {
 
 	return nil
 }
-// TODO: need to call ifconfig to add ip address to port


### PR DESCRIPTION
Configuring the port with the local IP address is a crucial step in
configuring a network with Open vSwitch.